### PR TITLE
support custom meta data for related files

### DIFF
--- a/examples/create_user_cloud_dataset.py
+++ b/examples/create_user_cloud_dataset.py
@@ -2,13 +2,24 @@ from mindkosh import Client
 
 client = Client('token')
 
-# create dataset
+# create user cloud dataset for s3
 dataset = client.create_dataset_from_cloud_data(
     name = 'sample user cloud dataset',
     data_type = 'pointcloud',
     resource = 'dataset-sample-3',
-    directory = '228c712b-154e-41f0-bc36-d3bd3da9f701/',
-    location = 'ap-south-1'
+    directory = 'sample-files/',
+    location = 'ap-south-1',
+    cloud_service_type='aws'
+)
+
+# create user cloud dataset for gcp
+dataset = client.create_dataset_from_cloud_data(
+    name = 'test-gcp-dataset',
+    data_type='pointcloud',
+    directory='',
+    resource='test-bucket-1',
+    location='asia-south-2',
+    cloud_service_type='gcp'
 )
 
 # scan files

--- a/mindkosh/client.py
+++ b/mindkosh/client.py
@@ -303,7 +303,7 @@ class Client:
                 logger.info(msg)
                 return msg
             
-            elif response.status_code == requests.code.bad_request:
+            elif response.status_code == requests.codes.bad_request:
                 raise Exception(response.text)
             response.raise_for_status()
 
@@ -557,7 +557,7 @@ class Client:
         uploader = DataSetUploader(
             dataset_id, batch_key, file_upload_url, stream_url, self.auth_header, data_type)
         files_uploaded = uploader.files_upload_thread(raw_filepaths=files_to_upload, tags=tags, extra=extra)
-        self._update_files_count(files_uploaded,data_type)
+        #self._update_files_count(files_uploaded,data_type)
 
     def upload_imagefiles(
             self,
@@ -614,7 +614,7 @@ class Client:
         uploader = DataSetUploader(
             dataset_id, batch_key, file_upload_url, stream_url, self.auth_header, data_type)
         files_uploaded = uploader.files_upload_thread(imagefiles=imagefiles)
-        self._update_files_count(files_uploaded,data_type)
+        #self._update_files_count(files_uploaded,data_type)
     
 
     def _upload_basefiles(self, dataset_id, data_type, basefiles):
@@ -661,12 +661,12 @@ class Client:
             logger.warning(f"Uploading {len(related_imagefiles)} related files")
             files_uploaded = uploader.files_upload_thread(imagefiles=related_imagefiles, run_streaming_thread=True)
             uploader.event.clear()
-            self._update_files_count(files_uploaded,Dataset.DataType.IMAGE)
+            #self._update_files_count(files_uploaded,Dataset.DataType.IMAGE)
             time.sleep(10)
 
         logger.warning(f"Uploading {len(basefiles)} {basefile_class.lower()}s")
         files_uploaded = uploader.files_upload_thread(basefiles=basefiles)
-        self._update_files_count(files_uploaded,data_type)
+        #self._update_files_count(files_uploaded,data_type)
 
 
     def upload_mainimages(
@@ -739,4 +739,3 @@ class Client:
 
             if incoming_storage and self.org.storage_consumed_in_bytes + incoming_storage > sub['values']['max_storage']:
                 raise SubscriptionError('Organization has exhausted the maximum storage allowed under current Subscription plan')
-

--- a/mindkosh/client.py
+++ b/mindkosh/client.py
@@ -234,12 +234,16 @@ class Client:
             data_type: str,
             resource: str,
             directory: str,
-            location: str = 'ap-south-1'
+            location: str,
+            cloud_service_type: str,
+            **kwargs
     ):
         data_type = data_type.lower()
         data_type = Dataset.DataType(data_type).value
         
-        cloud_service_type = 'aws'
+        cloud_service_type = cloud_service_type.lower()
+        if cloud_service_type not in ('aws', 'gcp'):
+            raise Exception("Invalid cloud service type")
         location = location or Dataset.DEFAULT_BUCKET_REGION
         url = self.api.datasets_storage_method('user_cloud')
         payload = {

--- a/mindkosh/datasets/helpers.py
+++ b/mindkosh/datasets/helpers.py
@@ -197,6 +197,16 @@ def verify_manifest(manifest, save_files_dir, dataset_id, category):
     return files
 
 
+def validate_custom_meta_data(data: dict = {}):
+    if len(data) > 10:
+        raise Exception(
+            "custom meta data can not contain more than 10 elements"
+        )
+    if any(isinstance(val, dict) for val in data.values()):
+        raise Exception(
+            "custom meta data doesn't support inner dicts"
+        )
+
 def validate_related_file_extra(extra: dict):
     errors = []
     device_id = extra.get('device_id', None)
@@ -271,6 +281,7 @@ def validate_user_cloud_manifest_file(manifest_filepath, data_type):
                 raise Exception(f"Invalid tags list for ref_image {filepath}")
             
             validate_related_file_extra(ref_img['camera_params'])
+            validate_custom_meta_data(ref_img.get('custom_meta_data', {}))
 
-    if len(sequence_list) != len(set(sequence_list)):
-        raise Exception("Duplicate sequence value found")
+    # if len(sequence_list) != len(set(sequence_list)):
+    #     raise Exception("Duplicate sequence value found")

--- a/mindkosh/datasets/models.py
+++ b/mindkosh/datasets/models.py
@@ -1,5 +1,6 @@
 import os
 import validators
+from mindkosh.datasets.helpers import validate_custom_meta_data
 from enum import Enum
 from mindkosh.exceptions import DatasetFileError
 
@@ -113,8 +114,11 @@ class ImageFile:
         if basefile_extension == '.pcd':
             allowed_extra.extend(['intrinsic', 'extrinsic', 'distortion', 'mirror', 'cameraModel'])
         
-        if not all(item in allowed_extra for item in self._extra):
-            raise DatasetFileError('RelatedFile.extra got unexpected items')
+        _custom_meta_data = {}
+        for k,v in self._extra.items():
+            if k not in allowed_extra:
+                _custom_meta_data[k] = v
+        validate_custom_meta_data(_custom_meta_data)
         
         errors = []        
         supported_url = self._extra.get('supported_file_url', None)


### PR DESCRIPTION
- Support gcp for user cloud datasets.
- Support `custom_meta_data` for `user-cloud` related files. 
- For `vk_cloud`, custom fields are allowed in `RelatedFile.extra`

```
# create user cloud dataset for gcp
dataset = client.create_dataset_from_cloud_data(
    name = 'test-gcp-dataset',
    data_type='pointcloud',
    directory='',
    resource='test-bucket-1',
    location='asia-south-2',
    cloud_service_type='gcp'
)
```

```
# scan files
# if manifest_file_path is None, it will try to scan all the files present at `dataset['directory']`
client.scan_user_cloud(
    dataset_id=dataset['id'],
    manifest_file_path= '/home/user/Desktop/sample_manifest_file.json'
)
```